### PR TITLE
Accept matrix product state again

### DIFF
--- a/src/controllers/state_controller.hpp
+++ b/src/controllers/state_controller.hpp
@@ -66,7 +66,7 @@ DISABLE_WARNING_POP
 #endif
 
 using int_t = int_fast64_t;
-using uint_t = uint_fast64_t; 
+using uint_t = uint_fast64_t;
 using complex_t = std::complex<double>;
 using complexf_t = std::complex<float>;
 using cvector_t = std::vector<complex_t>;
@@ -108,8 +108,8 @@ public:
   //-----------------------------------------------------------------------
   // Configuration
   //-----------------------------------------------------------------------
-  
-  // set configuration. 
+
+  // set configuration.
   // All of the configuration must be done before calling any gate operations.
   virtual void configure(const std::string& key, const std::string& value);
 
@@ -409,9 +409,9 @@ bool AerState::is_gpu(bool raise_error) const {
 void AerState::configure(const std::string& _key, const std::string& _value) {
 
   std::string key = _key;
-  std::transform(key.begin(), key.end(), key.begin(), ::tolower);  
+  std::transform(key.begin(), key.end(), key.begin(), ::tolower);
   std::string value = _value;
-  std::transform(value.begin(), value.end(), value.begin(), ::tolower);  
+  std::transform(value.begin(), value.end(), value.begin(), ::tolower);
 
   bool error = false;
   if (key == "method") {
@@ -441,7 +441,7 @@ void AerState::configure(const std::string& _key, const std::string& _value) {
   static std::unordered_set<std::string> str_config = { "method", "device", "precision", "extended_stabilizer_sampling_method",
                                                         "mps_sample_measure_algorithm", "mps_log_data", "mps_swap_direction"};
   static std::unordered_set<std::string> int_config = { "seed_simulator", "max_parallel_threads", "max_memory_mb", "parallel_state_update",
-                                                        "blocking_qubits", "batched_shots_gpu_max_qubits", "statevector_parallel_threshold", 
+                                                        "blocking_qubits", "batched_shots_gpu_max_qubits", "statevector_parallel_threshold",
                                                         "statevector_sample_measure_opt", "stabilizer_max_snapshot_probabilities",
                                                         "extended_stabilizer_metropolis_mixing_time", "extended_stabilizer_norm_estimation_samples",
                                                         "extended_stabilizer_norm_estimation_repetitions", "extended_stabilizer_parallel_threshold",
@@ -649,7 +649,7 @@ void AerState::initialize_qreg_state(std::shared_ptr<QuantumState::Base> state) 
           throw std::runtime_error("specified method does not support non-CPU device: method=superop");
     } else {
         throw std::runtime_error("not supported method.");
-    }    
+    }
   } else {
     state_ = state;
   }
@@ -764,14 +764,14 @@ AER::Vector<complex_t> AerState::move_to_vector() {
   flush_ops();
 
   Operations::Op op;
-  if (method_ == Method::statevector) {
+  if (method_ == Method::statevector || method_ == Method::matrix_product_state) {
     op.type = Operations::OpType::save_statevec;
     op.name = "save_statevec";
   } else if (method_ == Method::density_matrix) {
     op.type = Operations::OpType::save_state;
     op.name = "save_density_matrix";
   } else {
-    throw std::runtime_error("move_to_vector() supports only statevector or density_matrix methods");
+    throw std::runtime_error("move_to_vector() supports only statevector or matrix_product_state or density_matrix methods");
   }
   for (auto i = 0; i < num_of_qubits_; ++i)
     op.qubits.push_back(i);
@@ -781,7 +781,7 @@ AER::Vector<complex_t> AerState::move_to_vector() {
   ExperimentResult ret;
   state_->apply_op(op, ret, rng_, true);
 
-  if (method_ == Method::statevector) {
+  if (method_ == Method::statevector || method_ == Method::matrix_product_state) {
     auto vec = std::move(static_cast<DataMap<SingleData, Vector<complex_t>>>(std::move(ret).data).value()["s"].value());
     clear();
     return std::move(vec);
@@ -791,7 +791,7 @@ AER::Vector<complex_t> AerState::move_to_vector() {
     clear();
     return std::move(vec);
   } else {
-    throw std::runtime_error("move_to_vector() supports only statevector or density_matrix methods");
+    throw std::runtime_error("move_to_vector() supports only statevector or matrix_product_state or density_matrix methods");
   }
 };
 
@@ -801,14 +801,14 @@ matrix<complex_t> AerState::move_to_matrix() {
   flush_ops();
 
   Operations::Op op;
-  if (method_ == Method::statevector) {
+  if (method_ == Method::statevector || method_ == Method::matrix_product_state) {
     op.type = Operations::OpType::save_statevec;
     op.name = "save_statevec";
   } else if (method_ == Method::density_matrix) {
     op.type = Operations::OpType::save_state;
     op.name = "save_density_matrix";
   } else {
-    throw std::runtime_error("move_to_vector() supports only statevector or density_matrix methods");
+    throw std::runtime_error("move_to_matrix() supports only statevector or matrix_product_state or density_matrix methods");
   }
   for (auto i = 0; i < num_of_qubits_; ++i)
     op.qubits.push_back(i);
@@ -818,7 +818,7 @@ matrix<complex_t> AerState::move_to_matrix() {
   ExperimentResult ret;
   state_->apply_op(op, ret, rng_, true);
 
-  if (method_ == Method::statevector) {
+  if (method_ == Method::statevector || method_ == Method::matrix_product_state) {
     auto vec = std::move(
                 std::move(
                   std::move(
@@ -843,7 +843,7 @@ matrix<complex_t> AerState::move_to_matrix() {
     clear();
     return std::move(mat);
   } else {
-    throw std::runtime_error("move_to_vector() supports only statevector or density_matrix methods");
+    throw std::runtime_error("move_to_matrix() supports only statevector or matrix_product_state or density_matrix methods");
   }
 };
 
@@ -1210,7 +1210,7 @@ void AerState::initialize_experiment_result() {
     last_result_.metadata.add(device_names_.at(device_), "device");
   else
     last_result_.metadata.add("CPU", "device");
-  
+
   last_result_.metadata.add(num_of_qubits_, "num_qubits");
   last_result_.header = buffer_.header;
   last_result_.shots = 1;
@@ -1235,7 +1235,7 @@ void AerState::flush_ops() {
   buffer_.set_params(false);
   transpile_ops();
   state_->apply_ops(buffer_.ops.begin(), buffer_.ops.end(), last_result_, rng_);
-  
+
   finalize_experiment_result(true, std::chrono::duration<double>(myclock_t::now() - timer_start).count());
   clear_ops();
 };
@@ -1247,7 +1247,7 @@ void AerState::clear_ops() {
 
 void AerState::transpile_ops() {
   fusion_pass_ = Transpile::Fusion();
-  
+
   fusion_pass_.set_parallelization(parallel_state_update_);
 
   if (buffer_.opset().contains(Operations::OpType::superop))
@@ -1297,5 +1297,3 @@ void AerState::transpile_ops() {
 } // end namespace AER
 //-------------------------------------------------------------------------
 #endif
-
-

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -721,7 +721,7 @@ class TestAerStatevector(common.QiskitAerTestCase):
 
     def test_sample_counts_w(self):
         """Test sample_counts method for W state"""
-        shots = 3000
+        shots = 6000
         threshold = 0.02 * shots
         state = (
             AerStatevector.from_label("001")
@@ -756,7 +756,7 @@ class TestAerStatevector(common.QiskitAerTestCase):
     def test_sample_memory_ghz(self):
         """Test sample_memory method for GHZ state"""
 
-        shots = 2000
+        shots = 5000
         state = (AerStatevector.from_label("000") + AerStatevector.from_label("111")) / np.sqrt(2)
         state.seed(100)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

- Fixed to accept `method_ = Method::matrix_product_state`

### Details and comments

- Fixed to also accept `method_ = Method::matrix_product_state` in the paths that `method_ = Method::statevector` and `method_ = Method::product_state` were originally accepted before `method_ = Method::density_matrix` was added.

The followings are the functionalities implemented in addition to ensure smooth execution of the tests:

- Merge [#1673](https://github.com/Qiskit/qiskit-aer/pull/1673) to run tests for terra.states
- Increase shots to reduce fluctuations of the counts
